### PR TITLE
Removes gRPC overhead using a basic UDS server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,30 @@ $ pip install epic-stream-processor
 
 <!-- Please see the [Command-line Reference] for details. -->
 Creating a server instance
-```python
-from epic_stream_processor import server
+<pre>
+<del>from epic_stream_processor import server
 
 max_workers = 1
-server.serve(max_workers = max_workers)
-```
+server.serve(max_workers = max_workers)</del>
+from epic_stream_processor.epic_services import ThreadedServer
+
+ThreadedServer.listen()
+</pre>
 
 Sending data to the server using a client
-```python
-from epic_stram_processor.client import EpicRPCClient
+<pre>
+<del>from epic_stram_processor.client import EpicRPCClient
 
 rpc_client = EpicRPCClient()
-rpc_client.send_dummy_data()
+rpc_client.send_dummy_data()</del>
+import json
+from epic_stream_processor.epic_services import stream_packed_uds
+from epic_stream_processor._utils.Utils import get_thread_UDS_addr
 
 ...
-hdrs = [...] #list of stringified headers
-data = np.ndarray([...]) # data
-hdrs.append(d.shape)
 
-rpc_client.send_data()
-```
+stream_data_uds(primary_hdr, img_hdr, data)
+</pre>
 
 ## TODO
 - Add documentation

--- a/src/epic_stream_processor/_utils/__init__.py
+++ b/src/epic_stream_processor/_utils/__init__.py
@@ -1,7 +1,9 @@
 """Utility functions"""
 
+from .Utils import DynSources
 from .Utils import PatchMan
+from .Utils import get_epic_stpro_uds_id
 from .Utils import get_lmn_grid
 
 
-__all__ = ["get_lmn_grid", "PatchMan"]
+__all__ = ["get_lmn_grid", "PatchMan", "DynSources", "get_epic_stpro_uds_id"]

--- a/src/epic_stream_processor/epic_orm/pg_pixel_storage.py
+++ b/src/epic_stream_processor/epic_orm/pg_pixel_storage.py
@@ -94,7 +94,7 @@ class Database:
         stmnt = select(
             [
                 watch_d.id,
-                watch_d.source.label("name"),
+                watch_d.source.label("source_name"),
                 func.ST_X(watch_d.event_skypos).label("ra"),
                 func.ST_Y(watch_d.event_skypos).label("dec"),
                 watch_d.t_end.label("watch_until"),

--- a/src/epic_stream_processor/epic_services/__init__.py
+++ b/src/epic_stream_processor/epic_services/__init__.py
@@ -5,6 +5,18 @@ from . import server
 from . import service_hub
 from . import watch_dog
 from .server import epic_postprocessor
+from .uds_stream import ThreadedServer
+from .uds_stream import stream_data_uds
+from .uds_stream import stream_packed_uds
 
 
-__all__ = ["service_hub", "watch_dog", "server", "client", "epic_postprocessor"]
+__all__ = [
+    "service_hub",
+    "watch_dog",
+    "server",
+    "client",
+    "epic_postprocessor",
+    "ThreadedServer",
+    "stream_data_uds",
+    "stream_packed_uds",
+]

--- a/src/epic_stream_processor/epic_services/client.py
+++ b/src/epic_stream_processor/epic_services/client.py
@@ -1,21 +1,19 @@
 import json
-import socket
 import time
 from importlib.resources import path as res_path
 from pathlib import Path
-from queue import Empty
 from typing import Iterator
 from typing import List
 from typing import Optional
-from typing import Type
-from typing import TypeVar
+from typing import Tuple
 
 import grpc
+import numpy as np
 from astropy.io import fits
 
 from .. import example_data
+from .._utils import get_epic_stpro_uds_id
 from ..epic_grpc import epic_image_pb2
-from ..epic_grpc import epic_image_pb2_grpc
 from ..epic_grpc.epic_image_pb2 import empty
 from ..epic_grpc.epic_image_pb2 import epic_image
 from ..epic_grpc.epic_image_pb2_grpc import epic_post_processStub
@@ -34,27 +32,37 @@ class EpicRPCClient:
 
     def connect(self) -> None:
         self._channel = grpc.insecure_channel(
-            self.get_epic_ppro_uds_id(), options=[("grpc.max_send_message_length", -1)]
+            get_epic_stpro_uds_id(),
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_concurrent_streams", 100),
+                ("grpc.http2.lookahead_bytes", 1 << 13)
+                # ("SingleThreadedUnaryStream", 1),
+            ],
         )
         self._stub = epic_post_processStub(self._channel)
 
-    def get_epic_ppro_uds_id(self) -> str:
-        """
-        Query the central registry to get the UDS ID
-        """
-        # querying logic
-        return f"unix-abstract:{socket.gethostname()}_epic_processor"
+        # self._aio_channel = grpc.aio.insecure_channel(
+        #     get_epic_stpro_uds_id(),
+        #     options=[
+        #         ("grpc.max_send_message_length", -1),
+        #         ("SingleThreadedUnaryStream", 1),
+        #     ],
+        # )
+
+        # self._aio_stub = epic_post_processStub(self._aio_channel)
 
     def chunk_data(
         self,
         headers: List[str],
         data: NDArrayNum_t,
-        chunk_size: int = 819200,
+        chunk_size: int = 1 << 16,
     ) -> Iterator[epic_image]:
         size = data.size
         buffer = data
         image_cube = bytes()
         hdr: str = ""
+        print("CHUNK:", chunk_size)
         for i in range(0, size, chunk_size):
             hdr = json.dumps(headers) if i == 0 else ""
             if i + chunk_size > size:
@@ -64,42 +72,79 @@ class EpicRPCClient:
 
             yield epic_image_pb2.epic_image(header=hdr, image_cube=image_cube)
 
-    def get_dummy_data(self, n_iter: int = 10) -> Iterator[Iterator[epic_image]]:
+    def get_dummy_data(
+        self,
+        dataset: str = "EPIC_1661990950.000000_73.487MHz.fits",
+    ) -> Tuple[List[str], NDArrayNum_t]:
         test_file = Path(".")
-        with res_path(example_data, "EPIC_1661990950.000000_73.487MHz.fits") as f:
+        with res_path(example_data, dataset) as f:
             test_file = f
         with fits.open(test_file) as hdu:
-            for i in range(n_iter):
-                # header = json.dumps(dict(a=1,b=2))
-                # data = np.random.random(64*64*32*4*2) #
-                header = [hdu[0].header.tostring(), hdu[1].header.tostring()]
-                data = hdu[1].data
-                header.append(
-                    json.dumps(
-                        dict(
-                            dtype=str(data.dtype),
-                            shape=data.shape,
-                            strides=data.strides,
-                        )
+            header = [hdu[0].header.tostring(), hdu[1].header.tostring()]
+            data = hdu[1].data
+            data = np.random.random(data.shape).astype(np.float32)
+            header.append(
+                json.dumps(
+                    dict(
+                        dtype=str(data.dtype),
+                        shape=data.shape,
+                        strides=data.strides,
                     )
                 )
-                time.sleep(1)
-                yield self.chunk_data(header, data)
+            )
+        return header, data
 
-    def send_dummy_data(self) -> None:
-        with grpc.insecure_channel(
-            self.get_epic_ppro_uds_id(), options=[("grpc.max_send_message_length", -1)]
-        ) as channel:
-            print("Starting to send data")
-            try:
-                for i in self.get_dummy_data():
-                    t = time.time()
-                    print("Sending")
-                    _ = self._stub.filter_and_save_chunk(i)
-                    print(time.time() - t)
-            except Exception as e:
-                print("Unable to send data")
-                print(e)
+    def get_dummy_stream(
+        self,
+        n_iter: int = 10,
+        cadence: float = 1,
+        dataset: str = "EPIC_1661990950.000000_73.487MHz.fits",
+        chunk_size: int = 1 << 16,
+    ) -> Iterator[Iterator[epic_image]]:
+        # test_file = Path(".")
+        # with res_path(example_data, dataset) as f:
+        #     test_file = f
+        # th fits.open(test_file) as hdu:
+        header, data = self.get_dummy_data(dataset)
+        for _ in range(n_iter):
+            # header = json.dumps(dict(a=1,b=2))
+            # data = np.random.random(64*64*32*4*2) #
+            # header = [hdu[0].header.tostring(), hdu[1].header.tostring()]
+            # data = hdu[1].data
+            # data = np.random.random(data.shape).astype(data.dtype)
+            # header.append(
+            #     json.dumps(
+            #         dict(
+            #             dtype=str(data.dtype),
+            #             shape=data.shape,
+            #             strides=data.strides,
+            #         )
+            #     )
+            # )
+
+            time.sleep(cadence)
+            yield self.chunk_data(header, data, chunk_size=chunk_size)
+
+    def send_dummy_data(
+        self, n_items: int = 10, cadence: float = 1, chunk_size: int = 1 << 16
+    ) -> None:
+        # with grpc.insecure_channel(
+        #     self.get_epic_ppro_uds_id(),
+        #     options=[
+        #         ("grpc.max_send_message_length", -1),
+        #         # ("SingleThreadedUnaryStream", 1),
+        #     ],
+        # ) as channel:
+        print("Starting to send data")
+        try:
+            for i in self.get_dummy_stream(n_items, cadence, chunk_size=chunk_size):
+                t = time.time()
+                print("Sending")
+                _ = self._stub.filter_and_save_chunk(i)
+                print(time.time() - t)
+        except Exception as e:
+            print("Unable to send data")
+            print(e)
 
     def send_data(self, header_arr: List[str], data: NDArrayNum_t) -> Optional[empty]:
         try:
@@ -111,6 +156,20 @@ class EpicRPCClient:
         except Exception as e:
             print(e)
             return None
+
+    # async def send_data_aio(
+    #     self, header_arr: List[str], data: NDArrayNum_t
+    # ) -> Optional[empty]:
+    #     raise NotImplementedError()
+    #     try:
+    #         response: empty = await self._aio_stub.filter_and_save_chunk(
+    #             self.chunk_data(header_arr, data)
+    #         )
+
+    #         return response
+    #     except Exception as e:
+    #         print(e)
+    #         return None
 
     def __del__(self) -> None:
         if self._connected:

--- a/src/epic_stream_processor/epic_services/server.py
+++ b/src/epic_stream_processor/epic_services/server.py
@@ -1,13 +1,19 @@
 import json
 import socket
 from concurrent import futures
+from timeit import default_timer as timer
+from typing import Dict
 from typing import Iterator
 from typing import Optional
+from typing import Tuple
 
 import grpc
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 
+from epic_stream_processor.epic_types import NDArrayNum_t
+
+from .._utils import get_epic_stpro_uds_id
 from ..epic_grpc import epic_image_pb2
 from ..epic_grpc import epic_image_pb2_grpc
 from ..epic_grpc.epic_image_pb2 import empty
@@ -16,6 +22,7 @@ from ..epic_grpc.epic_image_pb2_grpc import (
     epic_post_processServicer as epic_post_servicer,
 )
 from .service_hub import ServiceHub
+from .watch_dog import EpicPixels
 from .watch_dog import WatchDog
 
 
@@ -30,10 +37,12 @@ class epic_postprocessor(epic_post_servicer):
         if storage_servicer is not None:
             self.storage_servicer = storage_servicer
 
-        if use_default_servicer == True:
+        if use_default_servicer is True:
             self.storage_servicer = ServiceHub()
 
         self.watcher = WatchDog(self.storage_servicer)
+        # self._pipeline = Stream(ensure_io_loop=True)
+        # self._pipeline.map(self._fs)#.sink(self._oblivion)
 
     def set_storage_servicer(self, servicer: ServiceHub) -> None:
         self.watcher.change_storage_servicer(servicer=servicer)
@@ -56,23 +65,37 @@ class epic_postprocessor(epic_post_servicer):
         request_iterator: Iterator[epic_image],
         context: object,
     ) -> empty:
-        header = []
-        img_buffer = bytes()
-        for image in request_iterator:
-            if image.header is not None:
-                header.append(image.header)
-            img_buffer += image.image_cube
+        # return empty()
+        # self._ppl.emit(request_iterator)
 
+        start = timer()
+        header = []
+        # img_buffer = bytearray()
+        # for image in request_iterator:
+        #     if image.header is not None:
+        #         header.append(image.header)
+        #     img_buffer += image.image_cube
+
+        def temp(hdr: str, img: bytes) -> bytes:
+            if hdr is not None:
+                header.append(hdr)
+            return img
+
+        img_buffer = [temp(i.header, i.image_cube) for i in request_iterator]
+        # img_buffer = b''.join(img_buffer)
+        print(f"Elapsed0: {timer()-start}")
         header = json.loads(header[0])
         # 0: primaryHDU, 1: Image, 2: buffer details
         buffer_metadata = json.loads(header[2])
 
         # decode the numpy array
-        img_array = np.frombuffer(img_buffer, dtype=buffer_metadata["dtype"])
+        img_array = np.frombuffer(b"".join(img_buffer), dtype=buffer_metadata["dtype"])
         img_array = as_strided(
             img_array, buffer_metadata["shape"], buffer_metadata["strides"]
         )
-
+        print(img_array.nbytes, 1 << 16, len(img_buffer))
+        print(f"Elapsed: {timer()-start}")
+        # return empty()
         # pixel_idx_df = watcher.get_watch_indices(header[1])
         # pixel_meta_df = pd.DataFrame.from_dict(
         #     watcher.header_to_metadict(header[1], epic_version='0.0.2'))
@@ -85,32 +108,62 @@ class epic_postprocessor(epic_post_servicer):
         # pixel_idx_df = watcher.format_skypos_pg(
         #     pixel_idx_df, 'patch_skypos', 'pixel_skypos')
 
-        pixel_idx_df, pixel_meta_df = self.watcher.filter_and_store_imgdata(
-            header[1], img_array, epic_version="0.0.2"
+        ###############
+        start = timer()
+        # pixel_idx_df, pixel_meta_df =
+        # self.watcher.filter_and_store_imgdata(
+        #     header[1], img_array, epic_version="0.0.2"
+        # )
+        pixels = EpicPixels(
+            header[1], header[0], img_array, self.watcher._watch_df, epic_ver="0.0.2"
         )
+        pixels.gen_pixdata_dfs()
+        pixels.store_pg(self.watcher._service_Hub)
+        # self._pipeline.emit((header[1], img_array, "0.0.2"))
+        print(f"Elapsed2: {timer()-start}")
+
+        # self._pipeline.emit((header[1], img_array, "0.0.2"))
+        ####################
 
         # print()
-        print(img_array.shape, pixel_idx_df.columns, pixel_meta_df.columns)
+        # print(img_array.shape, pixel_idx_df.columns, pixel_meta_df.columns)
         return empty()
 
 
-def get_uds_id() -> str:
-    """Returns an ID to register the processor on the registry service"""
-    # registration logic
-    return f"{socket.gethostname()}_epic_processor"
+# def get_uds_id() -> str:
+#     """Returns an ID to register the processor on the registry service"""
+#     # registration logic
+#     return f"{socket.gethostname()}_epic_processor"
 
 
 def serve(max_workers: int = 1) -> None:
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=max_workers),
         options=[("grpc.max_receive_message_length", -1)],
+        maximum_concurrent_rpcs=2,
     )
     print("Setting up")
     epic_image_pb2_grpc.add_epic_post_processServicer_to_server(
         epic_postprocessor(use_default_servicer=True), server
     )
-    server.add_insecure_port(f"unix-abstract:{get_uds_id()}")
+    server.add_insecure_port(get_epic_stpro_uds_id())
     print("Starting")
     server.start()
-    print(f"Running on {f'unix-abstract:{get_uds_id()}'}...")
+    print(f"Running on {get_epic_stpro_uds_id()}...")
     server.wait_for_termination()
+
+
+# async def serve_aio(max_workers: int = 1) -> None:
+#     server = grpc.aio.server(
+#         futures.ThreadPoolExecutor(max_workers=max_workers),
+#         options=[("grpc.max_receive_message_length", -1)],
+#     )
+#     print("Setting up (asyn mode)")
+#     epic_image_pb2_grpc.add_epic_post_processServicer_to_server(
+#         epic_postprocessor(use_default_servicer=True), server
+#     )
+#     server.add_insecure_port(get_epic_stpro_uds_id())
+#     print("Starting")
+#     await server.start()
+#     print(f"Running on {f'unix-abstract:{get_uds_id()}'}...")
+#     await server.wait_for_termination()

--- a/src/epic_stream_processor/epic_services/uds_stream.py
+++ b/src/epic_stream_processor/epic_services/uds_stream.py
@@ -1,0 +1,244 @@
+import json
+import socket
+import threading
+import traceback
+from importlib.resources import path as res_path
+from pathlib import Path
+# from socketserver import BaseServer
+# from socketserver import StreamRequestHandler
+# from socketserver import ThreadingUnixStreamServer
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from socket import socket as socket_c
+
+import numpy as np
+from astropy.io import fits
+from astropy.io.fits import Header
+from numpy.lib.stride_tricks import as_strided
+
+from .. import example_data
+from .._utils.Utils import get_thread_UDS_addr
+from ..epic_grpc.epic_image_pb2 import epic_image
+from ..epic_types import NDArrayNum_t
+from .service_hub import ServiceHub
+from .watch_dog import EpicPixels
+from .watch_dog import WatchDog
+
+
+try:
+    from socketserver import _AddressType
+    from socketserver import _RequestType
+    from socket import _RetAddress
+except Exception:
+    _RequestType = Union[Type[socket_c], Type[Tuple[bytes, socket_c]]]  # type: ignore[misc]
+    _AddressType = Union[Type[str], Type[Tuple[str, int]]]  # type: ignore[misc]
+    _RetAddress = Type[str]    # type: ignore[misc]
+
+
+# class EpicUDSHandler(StreamRequestHandler):
+#     def __init__(
+#         self, request: _RequestType, client_address: _AddressType, server: BaseServer
+#     ) -> None:
+#         super().__init__(request, client_address, server)
+#         # self._service_hub = ServiceHub()
+#         # self._watch_dog = WatchDog(self._service_hub)
+#         # print("Initialized the handler")
+
+#     def handle(self) -> None:
+#         buffer = bytes()
+#         try:
+#             while True:
+#                 data = self.rfile.readline()
+#                 # data = data.strip()
+#                 if data:
+#                     buffer += data
+#                 else:
+#                     break
+
+#             # print(buffer)
+#             # return
+#             img_data = epic_image.FromString(buffer)
+#             if img_data.ByteSize() == 0:
+#                 # wth?
+#                 return
+#             header = json.loads(img_data.header)
+#             # 0: primaryHdr, 1: ImageHdr, 2: buffer metadata
+#             buffer_metadata = json.loads(header[2])
+
+#             # decode the numpy array
+#             img_array = np.frombuffer(
+#                 b"".join(img_data.image_cube), dtype=buffer_metadata["dtype"]
+#             )
+
+#             # check the integrity of the array
+#             if img_array.size != np.prod(buffer_metadata["shape"]):
+#                 raise Exception(
+#                     f"Data lost in the transit. Expected shape {buffer_metadata['shape']} and deduced shape {img_array.shape} are unequal"
+#                 )
+
+#             img_array = as_strided(
+#                 img_array, buffer_metadata["shape"], buffer_metadata["strides"]
+#             )
+#             print("Received:", img_array.shape)
+
+#             pixels = EpicPixels(
+#                 header[1],
+#                 header[0],
+#                 img_array,
+#                 self._watch_dog._watch_df,
+#                 epic_ver="0.0.2",
+#             )
+#             pixels.gen_pixdata_dfs()
+#             pixels.store_pg(self._service_hub)
+
+#         except Exception as e:
+#             print("Exception")
+#             print(e)
+
+
+# def serve() -> None:
+#     addr = get_thread_UDS_addr()
+#     print("Setting up..")
+#     with ThreadingUnixStreamServer(
+#         addr, EpicUDSHandler, bind_and_activate=True
+#     ) as server:
+#         # server.allow_reuse_address = True
+#         server.socket.listen(6)
+#         print("Started")
+#         server.serve_forever()
+
+
+def stream_data_uds(primary_hdr: Header, img_hdr: Header, data: NDArrayNum_t, addr: Optional[str]) -> None:
+    addr = addr or get_thread_UDS_addr()
+    header = [primary_hdr.header.tostring(), img_hdr.header.tostring()]
+    header.append(
+        json.dumps(
+            dict(
+                dtype=str(data.dtype),
+                shape=data.shape,
+                strides=data.strides,
+            )
+        )
+    )
+    
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(addr)
+        client.send(
+            epic_image(header=json.dumps(header), image_cube=data.tobytes()).SerializeToString()
+        )
+
+
+def get_dummy_data(
+    dataset: str = "EPIC_1661990950.000000_73.487MHz.fits", randomize: bool = True
+) -> Tuple[List[str], NDArrayNum_t]:
+    test_file = Path(".")
+    with res_path(example_data, dataset) as f:
+        test_file = f
+    with fits.open(test_file) as hdu:
+        header = [hdu[0].header.tostring(), hdu[1].header.tostring()]
+        data = (
+            np.random.random(hdu[1].data.shape).astype(np.float32)
+            if randomize is True
+            else hdu[1].data
+        )
+        header.append(
+            json.dumps(
+                dict(
+                    dtype=str(data.dtype),
+                    shape=data.shape,
+                    strides=data.strides,
+                )
+            )
+        )
+    return header, data
+
+
+def stream_packed_uds(hdr: str, data: NDArrayNum_t, addr: str) -> None:
+    addr = addr or get_thread_UDS_addr()
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(addr)
+        client.sendall(
+            epic_image(header=hdr, image_cube=data.tobytes()).SerializeToString()
+        )
+    # sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    # sock.connect(addr)
+    # sock.sendall(epic_image(header=hdr, image_cube=data.tobytes()).SerializeToString())
+    # sock.close()
+
+
+class ThreadedServer(object):
+    def __init__(self, addr: Optional[str], max_conn: int = 5) -> None:
+        self.addr = addr or get_thread_UDS_addr()
+        self.max_conn = max_conn
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        #self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(self.addr)
+        self._service_hub = ServiceHub()
+        self._watch_dog = WatchDog(self._service_hub)
+
+    def listen(self) -> None:
+        self.sock.listen(self.max_conn)
+        while True:
+            client, address = self.sock.accept()
+            client.settimeout(60)
+            threading.Thread(
+                target=self.listen_to_client, args=(client, address)
+            ).start()
+
+    def listen_to_client(self, client: socket_c, address: _RetAddress) -> None:
+        size = 1 << 20
+        buffer = bytes()
+        while True:
+            try:
+                data = client.recv(size)
+                if data:
+                    # Set the response to echo back the recieved data
+                    buffer += data
+                    # client.send(response)
+                else:
+                    break
+                    # raise Exception("Client disconnected")
+            except Exception:
+                client.close()
+
+        try:
+            img_data = epic_image.FromString(buffer)
+            if img_data.ByteSize() == 0:
+                # wth?
+                return
+            header = json.loads(img_data.header)
+            # 0: primaryHdr, 1: ImageHdr, 2: buffer metadata
+            buffer_metadata = json.loads(header[2])
+
+            # decode the numpy array
+            img_array = np.frombuffer(
+                img_data.image_cube, dtype=buffer_metadata["dtype"]
+            )
+
+            # check the integrity of the array
+            if img_array.size != np.prod(buffer_metadata["shape"]):
+                raise Exception(
+                    f"Data lost in the transit. Expected shape {buffer_metadata['shape']} and deduced shape {img_array.shape} are unequal"
+                )
+
+            img_array = as_strided(
+                img_array, buffer_metadata["shape"], buffer_metadata["strides"]
+            )
+            print("Received:", img_array.shape)
+
+            pixels = EpicPixels(
+                header[1],
+                header[0],
+                img_array,
+                self._watch_dog._watch_df,
+                epic_ver="0.0.2",
+            )
+            pixels.gen_pixdata_dfs()
+            pixels.store_pg(self._service_hub)
+
+        except Exception:
+            #print("Exception")
+            print(print(traceback.format_exc()))

--- a/src/epic_stream_processor/epic_types.py
+++ b/src/epic_stream_processor/epic_types.py
@@ -1,5 +1,4 @@
 from typing import Tuple
-from typing import TypeVar
 from typing import Union
 
 import numpy as np
@@ -8,6 +7,8 @@ from numpy.typing import NDArray
 
 Numeric_t = Union[np.int64, np.float64]
 NDArrayNum_t = Union[NDArray[np.int64], NDArray[np.float64]]
+NDArrayStr_t = NDArray[np.str_]
+NDArrayBool_t = NDArray[np.bool_]
 Patch_t = Union[int, str]
 WatchMode_t = str
 PixCoord2d_t = Tuple[Numeric_t, Numeric_t]

--- a/src/epic_stream_processor/sql_scripts/create_pixel_tables.sql
+++ b/src/epic_stream_processor/sql_scripts/create_pixel_tables.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS epic_pixels (
 	pixel_values FLOAT [] NOT NULL,
 	pixel_coord POINT NOT NULL,
 	pixel_lm POINT,
-	source_names TEXT [] NOT NULL
+	source_names TEXT NOT NULL
 );
 
 SELECT

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,6 @@
 from typing import Type
 
 from pytest_pgsql import PostgreSQLTestDB
-from sqlalchemy import create_engine
 
 from epic_stream_processor import client
 from epic_stream_processor.epic_grpc.epic_image_pb2_grpc import epic_post_processStub
@@ -9,7 +8,7 @@ from epic_stream_processor.epic_services.server import epic_postprocessor
 from epic_stream_processor.epic_services.service_hub import ServiceHub
 
 
-def test_send_dummy_data(
+def test_send_dummy_dataset(
     grpc_stub: Type[epic_post_processStub],
     postgresql_db: Type[PostgreSQLTestDB],
     grpc_servicer: epic_postprocessor,
@@ -19,7 +18,13 @@ def test_send_dummy_data(
     # service_hub._connect_pgdb()
     service_hub._pgdb.create_all_tables()
     rpc_client = client.EpicRPCClient()
-    _ = grpc_stub.filter_and_save_chunk(next(rpc_client.get_dummy_data(1)))
+    _ = grpc_stub.filter_and_save_chunk(
+        next(
+            rpc_client.get_dummy_stream(
+                1, dataset="EPIC_1664482830.000000_36.487MHz.fits"
+            )
+        )
+    )
 
 
 # coverage run --parallel -m pytest --grpc-fake-server --pg-extensions=postgis


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

Fixes #

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Why?
The previous gRPC-based implementation introduced a 30-40 ms overhead to transfer the images from epic, which may become further higher with larger data sizes. This can be a problem if we want to move to higher temporal resolutions.

## What?
This PR swaps the gRPC server with a simple threaded UNIX domain socket-based server to be able to transfer the data. Preliminary tests indicate an overhead of 4-6 ms. If necessary, Cap'n proto RPC can be introduced which provides zero-copy RPC features using mmap.
